### PR TITLE
Temporarily set Sandland under maintenance

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -65,7 +65,7 @@
     "utility_list": false,
     "image_contains_title": true,
     "DisplayVersionOnlyInInstallerView": false,
-    "force_down": false,
+    "force_down": true,
     "links": {
       "image": "https://camo.githubusercontent.com/64a1e66bc236b32ed463f5131258bddbd60432de391c4634ea2e3b70c3e08f70/68747470733a2f2f692e696d6775722e636f6d2f784143345477472e6a706567",
       "readme": "https://github.com/Millionsfrost/N.Y.A-NSFW-Modlist-Skyrim/blob/main/Sandland-Fallout-4-SFW.md",


### PR DESCRIPTION
As your latest Discord announcement, if you know Sandland isn't installable at the moment,
do your and Wabbajack users a favour and set it under maintenance so they know it isn't installable at the moment.